### PR TITLE
add useInterval custom hook

### DIFF
--- a/useInterval.js
+++ b/useInterval.js
@@ -1,0 +1,38 @@
+import { useCallback, useRef,useEffect } from "react";
+
+/**
+ *
+ * @param {Function} callback
+ * @param {number} interval
+ * @returns {{clear:Function, reset:Function}} `clear` function clears the Interval and `reset` function restarts the setInterval with the given interval
+ */
+export default function useInterval(callback, interval) {
+
+  const callbackRef = useRef(callback)
+  const intervalRef = useRef()
+
+  useEffect(() => {
+    callbackRef.current = callback
+  }, [callback])
+
+  const set = useCallback(() => {
+    intervalRef.current = setInterval(callbackRef.current, interval)
+  }, [interval])
+
+  const clear = useCallback(() => {
+    intervalRef.current && clearInterval(intervalRef.current)
+  }, [])
+
+  useEffect(() => {
+
+    set()
+    return clear
+  }, [interval, set, clear])
+
+  const reset = useCallback(() => {
+    clear()
+    set()
+  }, [set, clear])
+
+  return { clear, reset }
+}


### PR DESCRIPTION
This hook can come in very handy when you want to use `setInterval` inside a react component.
It returns two functions, both wrapped inside of `useCallback` hook.
1. `clear` - To clear the interval.
2.  `reset` - To restart the setInterval. 