### PR TITLE
useTimeout and UseQueue hook

### DIFF
--- a/useQueue.js
+++ b/useQueue.js
@@ -1,0 +1,44 @@
+import { useCallback, useState } from "react";
+
+/**
+ *
+ * @param {Array} initialValue
+ */
+export default function useQueue(initialValue) {
+
+  const [state, setState] = useState(initialValue)
+
+  const enqueue = useCallback((value) => {
+
+    setState(prev => [...prev, value])
+
+  }, [])
+
+  const dequeue = useCallback(() => {
+
+    setState(([first, ...rest]) => rest)
+
+  }, [])
+
+
+  return {
+    enqueue,
+    dequeue,
+    get first() {
+      return state[0]
+    },
+    get last() {
+      return state.length === 0 ? undefined : state[state.length - 1]
+    },
+    get isEmpty() {
+      return state.length === 0
+    },
+    get state() {
+      return state
+    },
+    get size() {
+      return state.length
+    }
+  }
+
+}

--- a/useTimeout.js
+++ b/useTimeout.js
@@ -1,0 +1,38 @@
+import { useCallback, useEffect, useRef } from "react"
+
+
+const useTimeout = (callback, delay) => {
+
+  const callbackRef = useRef(callback)
+  const timeoutRef = useRef()
+
+  useEffect(() => {
+
+    callbackRef.current = callback
+
+  }, [callback])
+
+  const set = useCallback(() => {
+    timeoutRef.current = setTimeout(callbackRef.current, delay)
+  }, [delay])
+
+  const clear = useCallback(() => {
+    timeoutRef.current && clearTimeout(timeoutRef.current)
+  }, [])
+
+  useEffect(() => {
+    set()
+    return clear
+  }, [delay, set, clear])
+
+  const reset = useCallback(() => {
+    clear()
+    set()
+  }, [set, clear])
+
+  return { clear, reset }
+
+}
+
+
+export default useTimeout


### PR DESCRIPTION
1. `useQueue` - This hook provides methods and properties to manage a queue.
    - `enqueue` - (method) to insert (at the end).
    - `dequeue` - (method) to remove element (from the start)
    - `first` - (property) the first element, returns `undefined` if queue is empty.
    - `last` - (property) last element, returns `undefined` if queue is empty.
    - `isEmpty` - (property) returns `true`, if queue has no elements else `false`.
    - `state` - (property) returns the complete queue as Array.
    - `size` - (property) total number of elements in the queue.

2. `useTimeout` - This hook is a wrapper around `setTimeout` and returns two methods to manage the timeout.
    - `reset` - restart the timeout.
    - `clear` - clears the timeout.